### PR TITLE
remove: setup-go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,6 @@ jobs:
         with:
           aqua_version: v2.16.3
 
-      - name: Set up Go
-        uses: actions/setup-go@v4.1.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - name: Run golangci-lint
         run: golangci-lint run
 


### PR DESCRIPTION
I removed actions/setup-go from test workflow because using the aqua to setup golang.